### PR TITLE
make rest API depend on db manager interface rather than structure

### DIFF
--- a/api/entity_api.go
+++ b/api/entity_api.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 
-	eram "github.com/Onefootball/entity-rest-api/manager"
 	"github.com/ant0ine/go-json-rest/rest"
 )
 
@@ -18,11 +17,20 @@ const (
 	LocationHeader   = "Location"
 )
 
-type EntityRestAPI struct {
-	em *eram.EntityDbManager
+type entityDbManager interface {
+	GetIdColumn(entity string) string
+	GetEntities(entity string, filterParams map[string]string, limit string, offset string, orderBy string, orderDir string) ([]map[string]interface{}, int, error)
+	GetEntity(entity string, id string) (map[string]interface{}, error)
+	PostEntity(entity string, postData map[string]interface{}) (int64, error)
+	UpdateEntity(entity string, id string, updateData map[string]interface{}) (int64, map[string]interface{}, error)
+	DeleteEntity(entity string, id string) (int64, error)
 }
 
-func NewEntityRestAPI(em *eram.EntityDbManager) *EntityRestAPI {
+type EntityRestAPI struct {
+	em entityDbManager
+}
+
+func NewEntityRestAPI(em entityDbManager) *EntityRestAPI {
 	return &EntityRestAPI{
 		em,
 	}

--- a/api/entity_api_test.go
+++ b/api/entity_api_test.go
@@ -46,12 +46,12 @@ func init() {
 	db, err := sql.Open("sqlite3", ":memory:")
 
 	if err != nil {
-		log.Fatal("An error '%s' was not expected when opening a stub database connection", err)
+		log.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
 	} else {
 
 		dat, err := ioutil.ReadFile("./../test.sql")
 		if err != nil {
-			log.Fatal("An error '%s' was not expected when opening sql file", err)
+			log.Fatalf("An error '%s' was not expected when opening sql file", err)
 		} else {
 			db.Exec(string(dat))
 		}
@@ -72,7 +72,7 @@ func init() {
 	)
 
 	if err != nil {
-		log.Fatal("An error '%s' was not expected when creating the router", err)
+		log.Fatalf("An error '%s' was not expected when creating the router", err)
 	}
 
 	api.SetApp(router)


### PR DESCRIPTION
Currently there is no way to mock or use different implementation of EntityDbManager that is used by rest api. Replacement of this dependency with interface makes it possible